### PR TITLE
Add Google Analytics (gtag.js) and update GTM setup

### DIFF
--- a/theme/input/_layout.cshtml
+++ b/theme/input/_layout.cshtml
@@ -37,14 +37,17 @@
                     'https://www.googletagmanager.com/gtm.js?id=' + i + dl; f.parentNode.insertBefore(j, f);
         })(window, document, 'script', 'dataLayer', 'GTM-5LJFC5LF');</script>
     <!-- End Google Tag Manager -->
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-80FM7X5DH2"></script>
+    <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag() { dataLayer.push(arguments); }
+        gtag('js', new Date());
+
+        gtag('config', 'G-80FM7X5DH2');
+    </script>
 </head>
 <body class="landing is-preload">
-    <!-- Google Tag Manager (noscript) -->
-    <noscript>
-        <iframe src="https://www.googletagmanager.com/ns.html?id=GTM-5LJFC5LF"
-                height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
-    <!-- End Google Tag Manager (noscript) -->
     <!-- Page Wrapper -->
     <div id="page-wrapper">
 


### PR DESCRIPTION
Updated _layout.cshtml to include Google Analytics tracking by adding the gtag.js script. Removed the noscript fallback for GTM. The gtag.js script is loaded asynchronously to avoid blocking page load. Initialized the dataLayer and defined a gtag function to push events. Configured gtag with tracking ID G-80FM7X5DH2.