### PR TITLE
Make img responsive in index.cshtml

### DIFF
--- a/theme/input/index.cshtml
+++ b/theme/input/index.cshtml
@@ -13,7 +13,7 @@ ArchiveTitle: => GetString("Title")
 <!-- Banner -->
 <section id="banner">
     <div class="inner">
-        <h2 style="padding-top:.75em"><img src="@Context.GetLink("/images/e13_white.svg")" alt="@Context.GetString("SiteTitle")" style="height:300px"></h2>
+        <h2 style="padding-top:.75em"><img src="@Context.GetLink("/images/e13_white.svg")" alt="@Context.GetString("SiteTitle")" style="height:300px; width:100%"></h2>
         <p> a Blog by JJ Bussert</p>
     </div>
     <span href="#one" class="more scrolly">Recent Posts</span>


### PR DESCRIPTION
Updated the `style` attribute of the `img` tag within the `h2` element in `index.cshtml` to include `width:100%` along with the existing `height:300px`. This ensures the image scales to 100% of its container's width while maintaining a height of 300 pixels, improving responsiveness across different screen sizes.

#### PR Classification
Design update to improve image responsiveness.

#### PR Summary
Updated the `img` tag's `style` attribute in `index.cshtml` to ensure the image scales to 100% of its container's width while maintaining a height of 300 pixels.
- `index.cshtml`: Modified `img` tag within `h2` element to include `width:100%` in the `style` attribute.
