### PR TITLE
Add word cloud styling and accessibility improvements

### DIFF
--- a/Web/theme/input/assets/sass/main.scss
+++ b/Web/theme/input/assets/sass/main.scss
@@ -2051,3 +2051,116 @@ pre {
 .smaller-font {
     font-size:smaller
 }
+
+
+ul.cloud {
+    list-style: none;
+    padding-left: 0;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    line-height: 2.75rem;
+    width: 100%;
+}
+
+ul.cloud a {
+    /*   
+  Not supported by any browser at the moment :(
+  --size: attr(data-weight number); 
+  */
+    --size: 4;
+    --color: #a33;
+    color: var(--color);
+    font-size: calc(var(--size) * 0.25rem + 0.5rem);
+    display: block;
+    padding: 0.125rem 0.25rem;
+    position: relative;
+    text-decoration: none;
+    border: none;
+    /* 
+  For different tones of a single color
+  opacity: calc((15 - (9 - var(--size))) / 15); 
+  */
+}
+
+ul.cloud a[data-weight="1"] {
+    --size: 1;
+}
+
+ul.cloud a[data-weight="2"] {
+    --size: 2;
+}
+
+ul.cloud a[data-weight="3"] {
+    --size: 3;
+}
+
+ul.cloud a[data-weight="4"] {
+    --size: 4;
+}
+
+ul.cloud a[data-weight="5"] {
+    --size: 6;
+}
+
+ul.cloud a[data-weight="6"] {
+    --size: 8;
+}
+
+ul.cloud a[data-weight="7"] {
+    --size: 10;
+}
+
+ul.cloud a[data-weight="8"] {
+    --size: 13;
+}
+
+ul.cloud a[data-weight="9"] {
+    --size: 16;
+}
+
+ul[data-show-value] a::after {
+    content: " (" attr(data-weight) ")";
+    font-size: 1rem;
+}
+
+ul.cloud li:nth-child(2n+1) a {
+    --color: #181;
+}
+
+ul.cloud li:nth-child(3n+1) a {
+    --color: #33a;
+}
+
+ul.cloud li:nth-child(4n+1) a {
+    --color: #c38;
+}
+
+ul.cloud a:focus {
+    outline: 1px dashed;
+}
+
+ul.cloud a::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 50%;
+    width: 0;
+    height: 100%;
+    background: var(--color);
+    transform: translate(-50%, 0);
+    opacity: 0.15;
+    transition: width 0.25s;
+}
+
+ul.cloud a:focus::before,
+ul.cloud a:hover::before {
+    width: 100%;
+}
+
+@media (prefers-reduced-motion) {
+    ul.cloud * {
+        transition: none !important;
+    }
+}

--- a/Web/theme/input/tags.cshtml
+++ b/Web/theme/input/tags.cshtml
@@ -9,16 +9,17 @@ ArchiveOrderDescending: true
 ArchiveTitle: => GetString("GroupKey")
 AllowComments: false
 ---
-@if (Document.ContainsKey(Keys.GroupKey))
+<ul class="cloud" role="navigation" aria-label="Webdev word cloud">
+    @if (Document.ContainsKey(Keys.GroupKey))
 {
-   @Html.Partial("/_posts.cshtml", Document)
+    @Html.Partial("/_posts.cshtml", Document)
 }
 else
-{ 
+{
     foreach (IDocument tag in Document.GetChildren().OrderBy(x => x.GetTitle()))
     {
         string postCount = tag.GetChildren().Count().ToString();
-        string fontSize = postCount + "em";
-        <a role="button" href="@Context.GetLink(tag)" class="badge badge-light" style="white-space: nowrap;font-size: @fontSize"> @tag.GetTitle() (@postCount)</a>
+    <li><a href="@Context.GetLink(tag)" data-weight="@postCount"> @tag.GetTitle() (@postCount)</a></li>
     }
 }
+</ul>


### PR DESCRIPTION
Introduce a new `.cloud` class in `main.scss` to style a list of links as a word cloud. The `.cloud` class includes flexbox layout, alignment, and dynamic link appearance based on `data-weight` attributes. Specific styles for `data-weight` values (1-9) adjust font size and color. Additional styles include appending `data-weight` values to link text, changing link colors based on position, and adding focus and hover effects.

Update `tags.cshtml` to wrap tag links in a `<ul class="cloud">` element, removing previous inline styles. Add `role="navigation"` and `aria-label="Webdev word cloud"` for accessibility. Include a media query to disable transitions for users who prefer reduced motion.